### PR TITLE
Fix error of TARGET_OTA_ASSERT_DEVICE

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -5544,7 +5544,7 @@ ifeq ($(TARGET_FLATTEN_APEX),false)
 	$(hide) echo "target_flatten_apex=false" >> $@
 endif
 ifneq ($(TARGET_OTA_ASSERT_DEVICE),)
-        $(hide) echo "ota_override_device=$(TARGET_OTA_ASSERT_DEVICE)" >> $@
+	$(hide) echo "ota_override_device=$(TARGET_OTA_ASSERT_DEVICE)" >> $@
 endif
 
 $(call declare-0p-target,$(INSTALLED_MISC_INFO_TARGET))


### PR DESCRIPTION
Due to incorrect position of $(hide), not enable to set ota_override_device correctly