### PR TITLE
target: Exclude Sample APN when compiling a superior based build.

### DIFF
--- a/target/product/aosp_product.mk
+++ b/target/product/aosp_product.mk
@@ -27,5 +27,7 @@ PRODUCT_PACKAGES += \
 
 # Telephony:
 #   Provide a APN configuration to GSI product
+ifeq ($(SUPERIOR_BUILD),)
 PRODUCT_COPY_FILES += \
     device/sample/etc/apns-full-conf.xml:$(TARGET_COPY_OUT_PRODUCT)/etc/apns-conf.xml
+endif


### PR DESCRIPTION
* GSI Targets like husky fail without this. Inspired by LOS